### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,56 @@
+# OctoAcme Project Management Docs
+
+This directory serves as the canonical entry point to OctoAcme's project management knowledge base. Here you'll find process summaries, key workflows, example templates, personas, and direct links to each artifact describing how OctoAcme runs projects from start to finish.
+
+---
+
+## Brief Overview of OctoAcme Project Management Processes
+
+OctoAcme follows a robust, phase-driven project lifecycle:
+
+- **Initiation:** Validate business need, align stakeholders, define success criteria, and create a one-pager before proceeding.
+- **Planning:** Break work into shippable increments, maintain prioritized backlogs, record risks, and document acceptance and definition of done.
+- **Execution & Tracking:** Emphasize a strong meeting cadence (standups, weekly syncs, demos), track with project boards, and enforce small, testable PRs requiring CI and peer review.
+- **Release & Deployment:** All releases must meet pre-release requirements—passing CI, release notes, rollback plans, and post-deploy checks.
+- **Retrospective & Continuous Improvement:** Hold structured retros, capture learnings, and ensure action items are tracked to closure for ongoing improvement.
+
+**Key Roles:**  
+- Project Managers: Drive schedules, risks, and communications  
+- Product Managers: Shape outcomes, own priorities, and measure success  
+- Developers: Build, test, and collaborate  
+- QA/Testing: Ensure features meet quality and acceptance criteria
+
+**Quality & Communication:**  
+Quality assurance is embedded via automated and manual testing, and risk registers are maintained throughout the lifecycle. Communication uses weekly updates, stakeholder syncs, and formal escalation paths.
+
+---
+
+## Directory of Process Docs
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+---
+
+### Contributing & Improving These Docs
+
+1. Use the [Add Content to Project Management Process Docs](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml) template to propose updates.
+2. Clearly describe the change and its rationale.
+3. Submit a pull request and add `Chaitu74166` as a reviewer.
+
+---
+
+**Purpose of this Copilot Space:**  
+- Centralize scattered project management knowledge  
+- Convert team insights into standardized, searchable artifacts  
+- Enable consistent, repeatable execution  
+- Accelerate onboarding and reduce dependency risk  
+- Provide a single source of truth for workflows and decisions  
+
+_Last updated: 2026-03-19_


### PR DESCRIPTION
PR metadata:

Title: Add README for OctoAcme Project Management Docs
Description: Adds a complete README to the docs/ directory summarizing project management phases, roles, communication and QA practices, and links to all process documents. Closes #2.
Linked issue: #2 (“README for OctoAcme Project Management Docs: summary of project management processes & directory links to all docs”)
Reviewer: Chaitu74166
Label: documentation